### PR TITLE
feat(styling): refine dark-only theme and align prose colors with design tokens

### DIFF
--- a/content/projects/this-website.mdx
+++ b/content/projects/this-website.mdx
@@ -3,7 +3,7 @@ title: 'This Website!'
 date: '2025-09-06'
 description: 'My personal website for showcasing my data projects and writing. While my core expertise is in data, I developed this site from scratch with modern web tools.'
 imageUrl: '/images/projects/JamiePackerCom.svg'
-tags: ['Web Development', 'Next.js', 'React', 'TypeScript', 'Tailwind CSS v4']
+tags: ['Web Development', 'Next.js', 'React', 'TypeScript', 'Tailwind CSS']
 published: true
 liveUrl: 'https://jamiepacker.com'
 repoUrl: 'https://github.com/Jamie-Packer/My-Website'
@@ -16,17 +16,26 @@ And I assume that for most people this desire is satisfied by a social media pro
 But I think "social" media SUCKS, so my presence (if at all) on those platforms I keep limited. 
 
 Which is why I built this website. It's mine, it’s fully <span className="rainbow-text">customisable</span>,
-and it’s free from the brain-rot **SLOP** on *every* social media platform. 
+and it’s free from the brain-rot **SLOP** that you get on *every* social media platform. 
 Here people can find some information about me, see what I've been up to via my projects and articles, and get in contact with me.
+
+---
+<h2 id="stack" className="font-heading">The Stack</h2>
+
+- **Next.js**: The core framework for its routing and server-side rendering capabilities.
+- **TypeScript**: Used throughout the codebase to ensure type safety and improve code quality.
+- **React**: The library that powers all the user interface components.
+- **Tailwind CSS**: The styling framework used for its utility-first approach, which allows for rapid, consistent UI development.
+- **Vercel**: The platform used for deployment and hosting, providing a smooth path from development to production.
 
 
 ---
 <h2 id="dev" className="font-heading">Development</h2>
 
 When it comes to making a website, there are roughly three options:
- - Use an **"all-in-one" builder** (Wix/Squarespace): Non-technical, expensive subscription!
+ - Use an **"all-in-one" builder** (Wix/Squarespace): Non-technical, expensive!
  - **Hire a developer** or agency: Non-technical, expensive!  
- - **Do it yourself**, from scratch or with a template: Technical, cheap.
+ - **Do it yourself**, from scratch or with a template: Technical, cheap!.
 
 I created this website just after finishing university, so as you might guess, being broke and with time on my hands, I decided to build it myself.
 As my speciality is data science, not web development, the extent of my web-dev knowledge before this project was my base of programming knowledge + 
@@ -87,14 +96,6 @@ Another, rather embarrassing, mistake I made early on was pushing big commits di
 
 Despite these mistakes, the website came together pretty quick. I learnt a great deal and now have my very own website exactly how I want it :)
 
----
-<h2 id="stack" className="font-heading">The Stack</h2>
-
-- **Next.js**: The core framework for its routing and server-side rendering capabilities.
-- **TypeScript**: Used throughout the codebase to ensure type safety and improve code quality.
-- **React**: The library that powers all the user interface components.
-- **Tailwind CSS v4**: The styling framework used for its utility-first approach, which allows for rapid, consistent UI development.
-- **Vercel**: The platform used for deployment and hosting, providing a smooth path from development to production.
 
 ---
 <h2 id="future" className="font-heading">Potential Future Plans</h2>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,36 +1,32 @@
-/* src/globals.css */
+/* src/app/globals.css */
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-
+/* Theme tokens (dark-only) */
 :root {
-    --background: #ffffff; 
-    --background2: #bbbbbb;
-    --foreground: #1d1d1d;
-    --foreground2: #333333;
-    --accent: #800000;
+  --background: #1d1d1d;
+  --background2: #2d2d2d;
+  --foreground: #ffffff;   /* primary text (e.g., headings, default links) */
+  --foreground2: #cccccc;  /* secondary text (e.g., paragraphs) */
+  --accent: #800000;       /* brand accent */
+
+  /* Hint to the browser for native dark UI */
+  color-scheme: dark;
 }
 
+/* Tailwind v4 inline theme mapping */
 @theme inline {
   --color-background: var(--background);
+  --color-background2: var(--background2);
   --color-foreground: var(--foreground);
   --color-foreground2: var(--foreground2);
-  --color-background2: var(--background2);
   --color-accent: var(--accent);
+
   --font-sans: var(--font-body);
   --font-heading: var(--font-heading);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #1d1d1d;
-    --background2: #2d2d2d;
-    --foreground: #ffffff;
-    --foreground2: #cccccc;
-    --accent: #800000;
-  }
-}
-
+/* Base document */
 body {
   font-family: var(--font-body);
   background: var(--background);
@@ -41,38 +37,78 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Tailwind Typography → map to theme tokens for MDX (.prose) */
+.prose {
+  /* Body copy uses secondary text; headings use primary text */
+  --tw-prose-body: var(--foreground2);
+  --tw-prose-headings: var(--foreground);
 
-/* Custom Animations */
+  /* Links default to primary text; hover handled below */
+  --tw-prose-links: var(--foreground);
 
+  --tw-prose-bold: var(--foreground);
+  --tw-prose-counters: var(--foreground2);
+  --tw-prose-bullets: var(--foreground2);
+  --tw-prose-hr: color-mix(in oklab, var(--foreground) 15%, transparent);
+  --tw-prose-quotes: var(--foreground);
+  --tw-prose-quote-borders: color-mix(in oklab, var(--foreground) 25%, transparent);
+  --tw-prose-captions: var(--foreground2);
+  --tw-prose-code: var(--foreground);
+  --tw-prose-pre-bg: var(--background2);
+  --tw-prose-th-borders: color-mix(in oklab, var(--foreground) 18%, transparent);
+  --tw-prose-td-borders: color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+
+/* Invert variant kept for compatibility; values match dark-only theme */
+.prose.prose-invert {
+  --tw-prose-invert-body: var(--foreground2);
+  --tw-prose-invert-headings: var(--foreground);
+  --tw-prose-invert-links: var(--foreground);
+  --tw-prose-invert-bold: var(--foreground);
+  --tw-prose-invert-counters: var(--foreground2);
+  --tw-prose-invert-bullets: var(--foreground2);
+  --tw-prose-invert-hr: color-mix(in oklab, var(--foreground) 15%, transparent);
+  --tw-prose-invert-quotes: var(--foreground);
+  --tw-prose-invert-quote-borders: color-mix(in oklab, var(--foreground) 25%, transparent);
+  --tw-prose-invert-captions: var(--foreground2);
+  --tw-prose-invert-code: var(--foreground);
+  --tw-prose-invert-pre-bg: var(--background2);
+  --tw-prose-invert-th-borders: color-mix(in oklab, var(--foreground) 18%, transparent);
+  --tw-prose-invert-td-borders: color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+
+/* Prose link behavior: default = primary text; hover = accent */
+.prose :where(a) {
+  color: var(--foreground);
+  text-decoration-color: color-mix(in oklab, var(--foreground) 40%, transparent);
+}
+.prose :where(a:hover) {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+/* Optional: keep visited links the same as default */
+.prose :where(a:visited) {
+  color: var(--foreground);
+}
+
+/* Custom animations (unchanged) */
 @keyframes rainbow-scroll {
-  0% {
-    background-position: 0% 50%;
-  }
-  100% {
-    background-position: 100% 50%;
-  }
+  0%   { background-position: 0% 50%; }
+  100% { background-position: 100% 50%; }
 }
 
 @keyframes wobble {
-  0%, 100% {
-    transform: rotate(-6deg) translateY(0);
-  }
-  25% {
-    transform: rotate(6deg) translateY(-6px);
-  }
-  50% {
-    transform: rotate(-3deg) translateY(0);
-  }
-  75% {
-    transform: rotate(3deg) translateY(-10px);
-  }
+  0%, 100% { transform: rotate(-6deg) translateY(0); }
+  25%      { transform: rotate(6deg) translateY(-6px); }
+  50%      { transform: rotate(-3deg) translateY(0); }
+  75%      { transform: rotate(3deg) translateY(-10px); }
 }
 
 .rainbow-text {
-  vertical-align: bottom; /* shift alignment upward */
-  transform-origin: bottom center; /* wobble from the bottom edge */
-  font-size: 2.75rem; /* text-6xl */
-  font-weight: 800;   /* font-extrabold */
+  vertical-align: bottom;          /* align baseline visually */
+  transform-origin: bottom center; /* wobble pivot */
+  font-size: 2.75rem;              /* text-6xl */
+  font-weight: 800;                /* font-extrabold */
   display: inline-block;
   background: linear-gradient(
     270deg,
@@ -89,11 +125,7 @@ html {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  animation: rainbow-scroll 3s linear infinite alternate,
-             wobble 1.5s ease-in-out infinite;
+  animation:
+    rainbow-scroll 3s linear infinite alternate,
+    wobble 1.5s ease-in-out infinite;
 }
-
-
-
-
-


### PR DESCRIPTION
### Summary
This PR finalizes the dark-only theme setup and improves MDX prose styling so that body text, headings, and links use the correct design tokens.

### Changes
- Updated `globals.css`:
  - Set body text (`--tw-prose-body`) to `--foreground2` (grey).
  - Set heading text (`--tw-prose-headings`) to `--foreground` (white).
  - Default links now use `--foreground`; on hover they change to `--accent`.
  - Ensured both `.prose` and `.prose.prose-invert` map consistently to dark theme tokens.
- Retained animations and existing global styles without modification.

### Why
- It looks better in dark mode, suck it light users!
- Link behavior better matches the overall site design (neutral by default, accent on interaction).
- Keeps the site fully dark-only for consistency.

### Impact
- All MDX content (articles/projects) now matches the intended color hierarchy.
- Dark-only mode remains enforced; light mode is no longer supported.
