### PR TITLE
feat: per-page metadata, OG tags, and Tailwind class fixes

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getSortedContentData, getContentBySlug, ArticleMetadata } from '@/lib/content';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import YouTubeEmbed from '@/components/YouTubeEmbed';
@@ -11,6 +12,27 @@ export async function generateStaticParams() {
   return articles.map((article) => ({
     slug: article.slug,
   }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getContentBySlug<ArticleMetadata>("articles", slug);
+  if (!entry) return {};
+
+  const { title, description, imageUrl } = entry.metadata;
+  return {
+    title,
+    ...(description ? { description } : {}),
+    openGraph: {
+      title,
+      ...(description ? { description } : {}),
+      ...(imageUrl ? { images: [imageUrl] } : {}),
+    },
+  };
 }
 
 export default async function ArticlePage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,8 +1,14 @@
 // src/app/articles/page.tsx
 
+import type { Metadata } from "next";
 import Link from 'next/link';
 import ArticleSummary from '@/components/ArticleSummary';
 import { getSortedContentData, ArticleMetadata } from '@/lib/content';
+
+export const metadata: Metadata = {
+  title: "Articles",
+  description: "Articles and writing by Jamie Packer.",
+};
 
 const ArticlesPage = async () => {
   const articles = await getSortedContentData<ArticleMetadata>('articles');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,8 +21,13 @@ const faustina = Faustina({
 
 
 export const metadata: Metadata = {
-  title: "Jamie Packer",
-  description: "Jamie's personal website",
+  metadataBase: new URL("https://jamiepacker.com"),
+  title: {
+    template: "%s | Jamie Packer",
+    default: "Jamie Packer",
+  },
+  description:
+    "Jamie Packer — Data Science graduate. Projects, articles, and more.",
   icons: {
     icon: "/icon.svg",
     shortcut: "/favicon.png",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ const HomePage = () => {
           <h1 className="font-heading text-4xl sm:text-5xl lg:text-6xl font-bold mb-4">
             Hello, <br /> I'm <span className="text-accent">Jamie.</span>
           </h1>
-          <p className="text-lg sm:text-xl text-foreground2 max-w-xxl">
+          <p className="text-lg sm:text-xl text-foreground2 max-w-2xl">
             A Data Science graduate looking for my first role in the industry.
           </p>
           <a
@@ -44,21 +44,21 @@ const HomePage = () => {
         {/* 'Back to Top' Button */}
         <a 
           href="#" 
-          className="absolute top-16 left-1/2 -translate-x-1/2 bg-accent text-foreground rounded-full w-14 h-14 flex items-center justify-center text-2xl font-bold transition duration-200 hover:brightness-70"
+          className="absolute top-16 left-1/2 -translate-x-1/2 bg-accent text-foreground rounded-full w-14 h-14 flex items-center justify-center text-2xl font-bold transition duration-200 hover:brightness-75"
           aria-label="Back to top"
         >
           ↑
         </a>
 
         <div className="container mx-auto max-w-4xl">
-          <div className="flex flex-col md:flex-row items-center md:space-x-12">
-            <div className="md:w-1-2 mb-8 md:mb-0">
+          <div className="flex flex-col md:flex-row md:items-start md:gap-12">
+            <div className="md:flex-1 md:min-w-0 mb-8 md:mb-0">
               <h2 className="font-heading text-3xl font-bold mb-6">About Me</h2>
               <p className="text-foreground2 mb-8 text-lg">
                 Always learning! I enjoy working with data for <strong>tangible</strong> ends like building useful models, producing insightful analysis or creating the infrastructure for such things! My projects so far have focused on using python for feature engineering, machine learning and statistical analysis, and I'm currently learning more about data engineering. This site contains links and information on what i've been up to. Have a look around! :)
               </p>
               <div className="flex space-x-8">
-                <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank" rel="noopener noreferrer" className="text-foreground hover:text-accent transition-colors duration-200" aria-label="Email Me">
+                <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank" rel="noopener noreferrer" className="text-foreground hover:text-accent transition-colors duration-200">
                   <EmailIcon className="w-8 h-8" />
                 </a>
                 <a href="https://www.linkedin.com/in/jamie-packer-622101238/" target="_blank" rel="noopener noreferrer" className="text-foreground hover:text-accent transition-colors duration-200" aria-label="LinkedIn Profile">
@@ -69,24 +69,24 @@ const HomePage = () => {
                 </a>
               </div>
             </div>
-            <div className="md:w-1/2 flex flex-col space-y-4">
+            <div className="flex w-full max-w-xs md:w-28 md:max-w-none shrink-0 flex-col gap-4">
               <a
                 href="/Jamie_Packer_CV.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-accent hover:brightness-150 text-foreground font-bold py-3 px-6 rounded-md transition-colors duration-200 text-center flex-1"
+                className="block w-full bg-accent hover:brightness-150 text-foreground font-bold py-3 px-6 rounded-md transition-colors duration-200 text-center"
               >
                 View CV
               </a>
               <Link
                 href="/projects"
-                className="bg-background hover:brightness-130 text-foreground font-bold py-3 px-6 rounded-md transition-colors duration-200 text-center flex-1"
+                className="block w-full bg-background hover:brightness-125 text-foreground font-bold py-3 px-6 rounded-md transition-colors duration-200 text-center"
               >
                 My Projects
               </Link>
               <Link
                 href="/articles"
-                className="bg-background hover:brightness-130 text-foreground font-bold py-3 px-6 rounded-md transition-colors duration-200 text-center flex-1"
+                className="block w-full bg-background hover:brightness-125 text-foreground font-bold py-3 px-6 rounded-md transition-colors duration-200 text-center"
               >
                 My Articles
               </Link>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,4 +1,5 @@
 // src/app/projects/[slug]/page.tsx
+import type { Metadata } from "next";
 import { getSortedContentData, getContentBySlug, ProjectMetadata } from '@/lib/content';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import Image from 'next/image';
@@ -18,6 +19,27 @@ export async function generateStaticParams() {
   return projects.map((project) => ({
     slug: project.slug,
   }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = await getContentBySlug<ProjectMetadata>("projects", slug);
+  if (!entry) return {};
+
+  const { title, description, imageUrl } = entry.metadata;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [imageUrl],
+    },
+  };
 }
 
 export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,7 +1,14 @@
 // src/app/projects/page.tsx
 
+import type { Metadata } from "next";
 import ProjectCard from "@/components/ProjectCard";
 import { getSortedContentData, ProjectMetadata } from "@/lib/content";
+
+export const metadata: Metadata = {
+  title: "Projects",
+  description:
+    "A collection of links, information and write-ups about what I've been working on.",
+};
 
 export default async function ProjectsPage() {
   const projects = await getSortedContentData<ProjectMetadata>('projects');

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,12 +17,11 @@ const Footer = () => {
             <a href="https://www.linkedin.com/in/jamie-packer-622101238/" target="_blank" rel="noopener noreferrer" className="text-foreground2 hover:text-accent transition-colors duration-200" aria-label="LinkedIn Profile">
               <LinkedInIcon className="w-6 h-6" />
             </a>
-            <a 
-              href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" 
-              target="_blank" 
+            <a
+              href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+              target="_blank"
               rel="noopener noreferrer"
-              className="text-foreground2 hover:text-accent transition-colors duration-200" 
-              aria-label="Email Me"
+              className="text-foreground2 hover:text-accent transition-colors duration-200"
             >
               <EmailIcon className="w-6 h-6" />
             </a>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ const Navbar = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Mobile: spread out | Desktop: centered */}
         <div className="flex h-16 items-center justify-between md:justify-center">
-          <div className="flex w-full items-center justify-between font-heading md:w-auto md:space-x-8 md:space-x-2">
+          <div className="flex w-full items-center justify-between font-heading md:w-auto md:space-x-8">
             {/* Articles */}
             <Link
               href="/articles"

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -140,7 +140,7 @@ export default function TableOfContents({
                   href={`#${n.id}`}
                   onClick={handleClick(n.id)}
                   className={[
-                    "block rounded-xl px-2 py-1 text-large transition",
+                    "block rounded-xl px-2 py-1 text-lg transition",
                     depth === 0 ? "font-medium" : "opacity-90",
                     isActive ? "bg-foreground/10" : "hover:bg-foreground/5",
                     "text-foreground",

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -79,6 +79,8 @@ export async function getContentBySlug<T extends object>(
   type: Kind,
   slug: string
 ): Promise<{ metadata: WithSlug<T>; content: string } | null> {
+  if (!/^[a-z0-9-]+$/.test(slug)) return null;
+
   const fullPath = path.join(dirFor(type), `${slug}.mdx`);
 
   let raw: string;


### PR DESCRIPTION
## Summary

Improves SEO and sharing previews by wiring MDX frontmatter into Next.js metadata,
and fixes several Tailwind v4 class typos that were silently ignored. Also
restores the About section CTA buttons after a width utility fix exposed
`flex-1` stretching, and hardens slug handling in the content loader.

## Changes

- **Root layout:** `metadataBase`, title template (`%s | Jamie Packer`), updated default description
- **List pages:** static `metadata` on `/projects` and `/articles`
- **Detail pages:** `generateMetadata` for project/article slugs (title, description, OG image)
- **Content:** slug allowlist in `getContentBySlug` (`^[a-z0-9-]+$`)
- **Tailwind:** fix invalid utilities on home, navbar, and table of contents
- **About section:** compact CTA column (no `flex-1` on buttons; constrained width)
- **A11y:** remove incorrect `aria-label="Email Me"` on Rickroll links (URL unchanged)

## Test plan

- [ ] `npm run build` completes without errors
- [ ] Homepage tab title: `Jamie Packer`
- [ ] `/projects` tab: `Projects | Jamie Packer`
- [ ] Project detail tab uses project title from frontmatter
- [ ] About section CTAs are normal size on desktop and mobile
- [ ] Share a project URL in https://www.opengraph.xyz — title, description, image populate
- [ ] Invalid slug (e.g. `/projects/../etc`) returns 404